### PR TITLE
Add shapes support for scatter chart

### DIFF
--- a/src/constants/widget-data.ts
+++ b/src/constants/widget-data.ts
@@ -21,6 +21,14 @@ export enum DashStyle {
     Solid = 'Solid',
 }
 
+export enum DotStyle {
+    Circle = 'circle',
+    Diamond = 'diamond',
+    Square = 'square',
+    Triangle = 'triangle',
+    TriangleDown = 'triangle-down',
+}
+
 export enum LineCap {
     Butt = 'butt',
     Round = 'round',

--- a/src/constants/widget-data.ts
+++ b/src/constants/widget-data.ts
@@ -21,7 +21,7 @@ export enum DashStyle {
     Solid = 'Solid',
 }
 
-export enum DotStyle {
+export enum SymbolType {
     Circle = 'circle',
     Diamond = 'diamond',
     Square = 'square',

--- a/src/plugins/d3/renderer/components/Legend.tsx
+++ b/src/plugins/d3/renderer/components/Legend.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import {symbol, BaseType, select, line as lineGenerator} from 'd3';
 import type {Selection} from 'd3';
 
-import {getScatterSymbol} from '../utils';
+import {getSymbol} from '../utils';
 import {block} from '../../../../utils/cn';
 import type {
     OnLegendItemClick,
@@ -172,12 +172,13 @@ function renderLegendSymbol(args: {
                 element
                     .append('svg:path')
                     .attr('d', () => {
-                        const scatterSymbol = getScatterSymbol(
-                            (d.symbol as SymbolLegendSymbol).style,
+                        const scatterSymbol = getSymbol(
+                            (d.symbol as SymbolLegendSymbol).symbolType,
                         );
 
-                        // To cast pixel size to d3 size we need to multiply this value by 6
-                        return symbol(scatterSymbol, d.symbol.width * 6)();
+                        // D3 takes size as square pixels, so we need to make square pixels size by multiplying
+                        // https://d3js.org/d3-shape/symbol#symbol
+                        return symbol(scatterSymbol, d.symbol.width * d.symbol.width)();
                     })
                     .attr('transform', () => {
                         return 'translate(' + x + ',' + y + ')';

--- a/src/plugins/d3/renderer/components/Legend.tsx
+++ b/src/plugins/d3/renderer/components/Legend.tsx
@@ -176,7 +176,8 @@ function renderLegendSymbol(args: {
                             (d.symbol as SymbolLegendSymbol).style,
                         );
 
-                        return symbol(scatterSymbol, 48)();
+                        // To cast pixel size to d3 size we need to multiply this value by 6
+                        return symbol(scatterSymbol, d.symbol.width * 6)();
                     })
                     .attr('transform', () => {
                         return 'translate(' + x + ',' + y + ')';

--- a/src/plugins/d3/renderer/components/Legend.tsx
+++ b/src/plugins/d3/renderer/components/Legend.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
-import {BaseType, select, line as lineGenerator} from 'd3';
+import {symbol, BaseType, select, line as lineGenerator} from 'd3';
 import type {Selection} from 'd3';
 
+import {getScatterSymbol} from '../utils';
 import {block} from '../../../../utils/cn';
 import type {
     OnLegendItemClick,
@@ -9,6 +10,7 @@ import type {
     PreparedSeries,
     LegendItem,
     LegendConfig,
+    SymbolLegendSymbol,
 } from '../hooks';
 
 import {getLineDashArray} from '../hooks/useShapes/utils';
@@ -160,6 +162,25 @@ function renderLegendSymbol(args: {
                     .attr('height', d.symbol.height)
                     .attr('rx', d.symbol.radius)
                     .attr('class', className)
+                    .style('fill', color);
+
+                break;
+            }
+            case 'symbol': {
+                const y = legend.lineHeight / 2;
+
+                element
+                    .append('svg:path')
+                    .attr('d', () => {
+                        const scatterSymbol = getScatterSymbol(
+                            (d.symbol as SymbolLegendSymbol).style,
+                        );
+
+                        return symbol(scatterSymbol, 48)();
+                    })
+                    .attr('transform', () => {
+                        return 'translate(' + x + ',' + y + ')';
+                    })
                     .style('fill', color);
 
                 break;

--- a/src/plugins/d3/renderer/components/Legend.tsx
+++ b/src/plugins/d3/renderer/components/Legend.tsx
@@ -182,6 +182,7 @@ function renderLegendSymbol(args: {
                     .attr('transform', () => {
                         return 'translate(' + x + ',' + y + ')';
                     })
+                    .attr('class', className)
                     .style('fill', color);
 
                 break;

--- a/src/plugins/d3/renderer/components/styles.scss
+++ b/src/plugins/d3/renderer/components/styles.scss
@@ -32,6 +32,10 @@
         &_shape_path#{&}_unselected {
             stroke: var(--g-color-text-hint);
         }
+
+        &_shape_symbol#{&}_unselected {
+            fill: var(--g-color-text-hint);
+        }
     }
 
     &__item-text {

--- a/src/plugins/d3/renderer/hooks/useSeries/index.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/index.ts
@@ -64,7 +64,6 @@ export const useSeries = (args: Args) => {
     const chartSeries = React.useMemo<PreparedSeries[]>(() => {
         return preparedSeries.map((singleSeries, i) => {
             singleSeries.id = `Series ${i + 1}`;
-            singleSeries.index = i;
 
             if (singleSeries.legend.enabled) {
                 return {

--- a/src/plugins/d3/renderer/hooks/useSeries/index.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/index.ts
@@ -64,6 +64,7 @@ export const useSeries = (args: Args) => {
     const chartSeries = React.useMemo<PreparedSeries[]>(() => {
         return preparedSeries.map((singleSeries, i) => {
             singleSeries.id = `Series ${i + 1}`;
+            singleSeries.index = i;
 
             if (singleSeries.legend.enabled) {
                 return {

--- a/src/plugins/d3/renderer/hooks/useSeries/prepareSeries.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/prepareSeries.ts
@@ -25,10 +25,11 @@ type PrepareAxisRelatedSeriesArgs = {
     colorScale: ScaleOrdinal<string, string>;
     series: ChartKitWidgetSeries;
     legend: PreparedLegend;
+    index: number;
 };
 
 function prepareAxisRelatedSeries(args: PrepareAxisRelatedSeriesArgs): PreparedSeries[] {
-    const {colorScale, series, legend} = args;
+    const {colorScale, series, legend, index} = args;
     const preparedSeries = cloneDeep(series) as PreparedSeries;
     const name = 'name' in series && series.name ? series.name : '';
     preparedSeries.color = 'color' in series && series.color ? series.color : colorScale(name);
@@ -36,7 +37,7 @@ function prepareAxisRelatedSeries(args: PrepareAxisRelatedSeriesArgs): PreparedS
     preparedSeries.visible = get(preparedSeries, 'visible', true);
     preparedSeries.legend = {
         enabled: get(preparedSeries, 'legend.enabled', legend.enabled),
-        symbol: prepareLegendSymbol(series),
+        symbol: prepareLegendSymbol(series, index),
     };
 
     return [preparedSeries];
@@ -67,8 +68,10 @@ export function prepareSeries(args: {
             return prepareBarYSeries({series: series as BarYSeries[], legend, colorScale});
         }
         case 'scatter': {
-            return series.reduce<PreparedSeries[]>((acc, singleSeries) => {
-                acc.push(...prepareAxisRelatedSeries({series: singleSeries, legend, colorScale}));
+            return series.reduce<PreparedSeries[]>((acc, singleSeries, index) => {
+                acc.push(
+                    ...prepareAxisRelatedSeries({series: singleSeries, legend, colorScale, index}),
+                );
                 return acc;
             }, []);
         }

--- a/src/plugins/d3/renderer/hooks/useSeries/prepareSeries.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/prepareSeries.ts
@@ -11,6 +11,7 @@ import type {
     LineSeries,
     PieSeries,
 } from '../../../../../types';
+import {SymbolType} from '../../../../../constants';
 
 import {getSymbolType} from '../../utils';
 import {ScatterSeries} from '../../../../../types/widget-data';
@@ -36,7 +37,7 @@ function prepareAxisRelatedSeries(args: PrepareAxisRelatedSeriesArgs): PreparedS
     const preparedSeries = cloneDeep(series) as PreparedScatterSeries;
     const name = 'name' in series && series.name ? series.name : '';
 
-    const symbolType = (series as ScatterSeries).symbolType || getSymbolType(index);
+    const symbolType = ((series as ScatterSeries).symbolType || getSymbolType(index)) as SymbolType;
 
     preparedSeries.symbolType = symbolType;
     preparedSeries.color = 'color' in series && series.color ? series.color : colorScale(name);

--- a/src/plugins/d3/renderer/hooks/useSeries/prepareSeries.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/prepareSeries.ts
@@ -12,7 +12,10 @@ import type {
     PieSeries,
 } from '../../../../../types';
 
-import type {PreparedLegend, PreparedSeries} from './types';
+import {getSymbolType} from '../../utils';
+import {ScatterSeries} from '../../../../../types/widget-data';
+
+import type {PreparedLegend, PreparedSeries, PreparedScatterSeries} from './types';
 import {prepareLineSeries} from './prepare-line-series';
 import {prepareBarXSeries} from './prepare-bar-x';
 import {prepareBarYSeries} from './prepare-bar-y';
@@ -28,16 +31,20 @@ type PrepareAxisRelatedSeriesArgs = {
     index: number;
 };
 
-function prepareAxisRelatedSeries(args: PrepareAxisRelatedSeriesArgs): PreparedSeries[] {
+function prepareAxisRelatedSeries(args: PrepareAxisRelatedSeriesArgs): PreparedScatterSeries[] {
     const {colorScale, series, legend, index} = args;
-    const preparedSeries = cloneDeep(series) as PreparedSeries;
+    const preparedSeries = cloneDeep(series) as PreparedScatterSeries;
     const name = 'name' in series && series.name ? series.name : '';
+
+    const symbolType = (series as ScatterSeries).symbolType || getSymbolType(index);
+
+    preparedSeries.symbolType = symbolType;
     preparedSeries.color = 'color' in series && series.color ? series.color : colorScale(name);
     preparedSeries.name = name;
     preparedSeries.visible = get(preparedSeries, 'visible', true);
     preparedSeries.legend = {
         enabled: get(preparedSeries, 'legend.enabled', legend.enabled),
-        symbol: prepareLegendSymbol(series, index),
+        symbol: prepareLegendSymbol(series, symbolType),
     };
 
     return [preparedSeries];

--- a/src/plugins/d3/renderer/hooks/useSeries/types.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/types.ts
@@ -15,6 +15,7 @@ import {
     ConnectorShape,
     ConnectorCurve,
     PathLegendSymbolOptions,
+    SymbolLegendSymbolOptions,
     AreaSeries,
     AreaSeriesData,
 } from '../../../../../types';
@@ -30,7 +31,12 @@ export type PathLegendSymbol = {
     strokeWidth: number;
 } & Required<PathLegendSymbolOptions>;
 
-export type PreparedLegendSymbol = RectLegendSymbol | PathLegendSymbol;
+export type SymbolLegendSymbol = {
+    shape: 'symbol';
+    style: string;
+} & Required<SymbolLegendSymbolOptions>;
+
+export type PreparedLegendSymbol = RectLegendSymbol | PathLegendSymbol | SymbolLegendSymbol;
 
 export type PreparedLegend = Required<ChartKitWidgetLegend> & {
     height: number;

--- a/src/plugins/d3/renderer/hooks/useSeries/types.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/types.ts
@@ -20,7 +20,7 @@ import {
     AreaSeriesData,
 } from '../../../../../types';
 import type {SeriesOptionsDefaults} from '../../constants';
-import {DashStyle, LineCap} from '../../../../../constants';
+import {DashStyle, LineCap, SymbolType} from '../../../../../constants';
 
 export type RectLegendSymbol = {
     shape: 'rect';
@@ -33,7 +33,7 @@ export type PathLegendSymbol = {
 
 export type SymbolLegendSymbol = {
     shape: 'symbol';
-    symbolType: string;
+    symbolType: SymbolType;
 } & Required<SymbolLegendSymbolOptions>;
 
 export type PreparedLegendSymbol = RectLegendSymbol | PathLegendSymbol | SymbolLegendSymbol;
@@ -86,7 +86,7 @@ type BasePreparedSeries = {
 export type PreparedScatterSeries = {
     type: ScatterSeries['type'];
     data: ScatterSeriesData[];
-    symbolType: string;
+    symbolType: SymbolType;
 } & BasePreparedSeries;
 
 export type PreparedBarXSeries = {

--- a/src/plugins/d3/renderer/hooks/useSeries/types.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/types.ts
@@ -33,7 +33,7 @@ export type PathLegendSymbol = {
 
 export type SymbolLegendSymbol = {
     shape: 'symbol';
-    style: string;
+    symbolType: string;
 } & Required<SymbolLegendSymbolOptions>;
 
 export type PreparedLegendSymbol = RectLegendSymbol | PathLegendSymbol | SymbolLegendSymbol;
@@ -86,6 +86,7 @@ type BasePreparedSeries = {
 export type PreparedScatterSeries = {
     type: ScatterSeries['type'];
     data: ScatterSeriesData[];
+    symbolType: string;
 } & BasePreparedSeries;
 
 export type PreparedBarXSeries = {

--- a/src/plugins/d3/renderer/hooks/useSeries/types.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/types.ts
@@ -75,6 +75,7 @@ type BasePreparedSeries = {
     color: string;
     name: string;
     id: string;
+    index: number;
     visible: boolean;
     legend: {
         enabled: boolean;

--- a/src/plugins/d3/renderer/hooks/useSeries/types.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/types.ts
@@ -75,7 +75,6 @@ type BasePreparedSeries = {
     color: string;
     name: string;
     id: string;
-    index?: number;
     visible: boolean;
     legend: {
         enabled: boolean;

--- a/src/plugins/d3/renderer/hooks/useSeries/types.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/types.ts
@@ -75,7 +75,7 @@ type BasePreparedSeries = {
     color: string;
     name: string;
     id: string;
-    index: number;
+    index?: number;
     visible: boolean;
     legend: {
         enabled: boolean;

--- a/src/plugins/d3/renderer/hooks/useSeries/utils.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/utils.ts
@@ -19,10 +19,7 @@ export const getAllLegendItems = (series: PreparedSeries[]) => {
     return series.map((s) => s.name);
 };
 
-export function prepareLegendSymbol(
-    series: ChartKitWidgetSeries,
-    index: number,
-): PreparedLegendSymbol {
+export function prepareLegendSymbol(series: ChartKitWidgetSeries, index = 0): PreparedLegendSymbol {
     const scatterStyle = (series as ScatterSeries).symbol || getScatterStyle(index);
 
     return {

--- a/src/plugins/d3/renderer/hooks/useSeries/utils.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/utils.ts
@@ -1,8 +1,9 @@
 import memoize from 'lodash/memoize';
 import {PreparedLegendSymbol, PreparedSeries, StackedSeries} from './types';
-import {ChartKitWidgetSeries, RectLegendSymbolOptions} from '../../../../../types';
-import {DEFAULT_LEGEND_SYMBOL_PADDING, DEFAULT_LEGEND_SYMBOL_SIZE} from './constants';
+import {ChartKitWidgetSeries} from '../../../../../types';
 import {getRandomCKId} from '../../../../../utils';
+import {getScatterStyle} from '../../utils';
+import {ScatterSeries} from '../../../../../types/widget-data';
 
 export const getActiveLegendItems = (series: PreparedSeries[]) => {
     return series.reduce<string[]>((acc, s) => {
@@ -18,16 +19,17 @@ export const getAllLegendItems = (series: PreparedSeries[]) => {
     return series.map((s) => s.name);
 };
 
-export function prepareLegendSymbol(series: ChartKitWidgetSeries): PreparedLegendSymbol {
-    const symbolOptions: RectLegendSymbolOptions = series.legend?.symbol || {};
-    const symbolHeight = symbolOptions?.height || DEFAULT_LEGEND_SYMBOL_SIZE;
+export function prepareLegendSymbol(
+    series: ChartKitWidgetSeries,
+    index: number,
+): PreparedLegendSymbol {
+    const scatterStyle = (series as ScatterSeries).symbol || getScatterStyle(index);
 
     return {
-        shape: 'rect',
-        width: symbolOptions?.width || DEFAULT_LEGEND_SYMBOL_SIZE,
-        height: symbolHeight,
-        radius: symbolOptions?.radius || symbolHeight / 2,
-        padding: symbolOptions?.padding || DEFAULT_LEGEND_SYMBOL_PADDING,
+        shape: 'symbol',
+        style: scatterStyle,
+        padding: 0,
+        width: 8,
     };
 }
 

--- a/src/plugins/d3/renderer/hooks/useSeries/utils.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/utils.ts
@@ -3,6 +3,7 @@ import {PreparedLegendSymbol, PreparedSeries, StackedSeries} from './types';
 import {ChartKitWidgetSeries} from '../../../../../types';
 import {getRandomCKId} from '../../../../../utils';
 import {DEFAULT_LEGEND_SYMBOL_PADDING} from './constants';
+import {SymbolType} from '../../../../../constants';
 
 const DEFAULT_LEGEND_SYMBOL_SIZE = 8;
 
@@ -22,13 +23,13 @@ export const getAllLegendItems = (series: PreparedSeries[]) => {
 
 export function prepareLegendSymbol(
     series: ChartKitWidgetSeries,
-    symbolType?: string,
+    symbolType?: SymbolType,
 ): PreparedLegendSymbol {
     const symbolOptions = series.legend?.symbol || {};
 
     return {
         shape: 'symbol',
-        symbolType: symbolType || 'circle',
+        symbolType: symbolType || SymbolType.Circle,
         width: symbolOptions?.width || DEFAULT_LEGEND_SYMBOL_SIZE,
         padding: symbolOptions?.padding || DEFAULT_LEGEND_SYMBOL_PADDING,
     };

--- a/src/plugins/d3/renderer/hooks/useSeries/utils.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/utils.ts
@@ -2,10 +2,8 @@ import memoize from 'lodash/memoize';
 import {PreparedLegendSymbol, PreparedSeries, StackedSeries} from './types';
 import {ChartKitWidgetSeries} from '../../../../../types';
 import {getRandomCKId} from '../../../../../utils';
-import {DEFAULT_LEGEND_SYMBOL_PADDING} from './constants';
+import {DEFAULT_LEGEND_SYMBOL_PADDING, DEFAULT_LEGEND_SYMBOL_SIZE} from './constants';
 import {SymbolType} from '../../../../../constants';
-
-const DEFAULT_LEGEND_SYMBOL_SIZE = 8;
 
 export const getActiveLegendItems = (series: PreparedSeries[]) => {
     return series.reduce<string[]>((acc, s) => {

--- a/src/plugins/d3/renderer/hooks/useSeries/utils.ts
+++ b/src/plugins/d3/renderer/hooks/useSeries/utils.ts
@@ -2,8 +2,9 @@ import memoize from 'lodash/memoize';
 import {PreparedLegendSymbol, PreparedSeries, StackedSeries} from './types';
 import {ChartKitWidgetSeries} from '../../../../../types';
 import {getRandomCKId} from '../../../../../utils';
-import {getScatterStyle} from '../../utils';
-import {ScatterSeries} from '../../../../../types/widget-data';
+import {DEFAULT_LEGEND_SYMBOL_PADDING} from './constants';
+
+const DEFAULT_LEGEND_SYMBOL_SIZE = 8;
 
 export const getActiveLegendItems = (series: PreparedSeries[]) => {
     return series.reduce<string[]>((acc, s) => {
@@ -19,14 +20,17 @@ export const getAllLegendItems = (series: PreparedSeries[]) => {
     return series.map((s) => s.name);
 };
 
-export function prepareLegendSymbol(series: ChartKitWidgetSeries, index = 0): PreparedLegendSymbol {
-    const scatterStyle = (series as ScatterSeries).symbol || getScatterStyle(index);
+export function prepareLegendSymbol(
+    series: ChartKitWidgetSeries,
+    symbolType?: string,
+): PreparedLegendSymbol {
+    const symbolOptions = series.legend?.symbol || {};
 
     return {
         shape: 'symbol',
-        style: scatterStyle,
-        padding: 0,
-        width: 8,
+        symbolType: symbolType || 'circle',
+        width: symbolOptions?.width || DEFAULT_LEGEND_SYMBOL_SIZE,
+        padding: symbolOptions?.padding || DEFAULT_LEGEND_SYMBOL_PADDING,
     };
 }
 

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -58,12 +58,12 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
         const seriesIds: string[] = [];
 
         const selection = svgElement
-            .selectAll('point')
+            .selectAll('path')
             .data(preparedData, shapeKey)
             .join(
                 (enter) =>
                     enter
-                        .append('svg:path')
+                        .append('path')
                         .attr('class', b('point'))
                         .attr('transform', (d) => {
                             const size = d.data.radius || DEFAULT_SCATTER_POINT_SIZE;

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -5,12 +5,7 @@ import type {BaseType, Dispatch, Selection} from 'd3';
 
 import {block} from '../../../../../../utils/cn';
 
-import {
-    extractD3DataFromNode,
-    isNodeContainsD3Data,
-    getScatterStyle,
-    getScatterSymbol,
-} from '../../../utils';
+import {extractD3DataFromNode, isNodeContainsD3Data, getSymbol} from '../../../utils';
 import type {NodeWithD3Data} from '../../../utils';
 import {PreparedSeriesOptions} from '../../useSeries/types';
 import type {PreparedScatterData} from './prepare-data';
@@ -28,8 +23,6 @@ type ScatterSeriesShapeProps = {
 };
 
 const b = block('d3-scatter');
-
-const DEFAULT_SCATTER_POINT_SIZE = 8;
 
 const EMPTY_SELECTION = null as unknown as Selection<
     BaseType,
@@ -64,22 +57,16 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                 (exit) => exit.remove(),
             )
             .attr('d', (d) => {
-                const seriesIdIndex = d.series.index;
+                const symbolType = (d.series as ScatterSeries).symbolType || 'circle';
+                const scatterSymbol = getSymbol(symbolType);
 
-                const scatterStyle =
-                    (d.series as ScatterSeries).symbol || getScatterStyle(seriesIdIndex || 0);
-                const scatterSymbol = getScatterSymbol(scatterStyle);
-
-                const size = d.data.radius ? d.data.radius * 2 : DEFAULT_SCATTER_POINT_SIZE;
-
-                // To cast pixel size to d3 size we need to multiply this value by 6
-                return symbol(scatterSymbol, size * 6)();
+                // D3 takes size as square pixels, so we need to make square pixels size by multiplying
+                // https://d3js.org/d3-shape/symbol#symbol
+                return symbol(scatterSymbol, d.size * d.size)();
             })
             .attr('transform', (d) => {
-                const size = d.data.radius ? d.data.radius * 2 : DEFAULT_SCATTER_POINT_SIZE;
-
                 // Offset from top left point to center point of symbol shape
-                return 'translate(' + (d.cx - size / 2) + ',' + (d.cy - size / 2) + ')';
+                return 'translate(' + (d.cx - d.size / 2) + ',' + (d.cy - d.size / 2) + ')';
             })
             .attr('fill', (d) => d.data.color || d.series.color || '');
 

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -11,6 +11,7 @@ import {PreparedSeriesOptions} from '../../useSeries/types';
 import type {PreparedScatterData} from './prepare-data';
 import {shapeKey} from '../utils';
 import {ScatterSeries} from '../../../../../../types/widget-data';
+import {SymbolType} from '../../../../../../constants';
 
 export {prepareScatterData} from './prepare-data';
 export type {PreparedScatterData} from './prepare-data';
@@ -57,7 +58,7 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                 (exit) => exit.remove(),
             )
             .attr('d', (d) => {
-                const symbolType = (d.series as ScatterSeries).symbolType || 'circle';
+                const symbolType = (d.series as ScatterSeries).symbolType || SymbolType.Circle;
                 const scatterSymbol = getSymbol(symbolType);
 
                 // D3 takes size as square pixels, so we need to make square pixels size by multiplying

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -66,8 +66,7 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                 return symbol(scatterSymbol, d.size * d.size)();
             })
             .attr('transform', (d) => {
-                // Offset from top left point to center point of symbol shape
-                return 'translate(' + (d.cx - d.size / 2) + ',' + (d.cy - d.size / 2) + ')';
+                return 'translate(' + d.cx + ',' + d.cy + ')';
             })
             .attr('fill', (d) => d.data.color || d.series.color || '');
 

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -67,7 +67,7 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                 const seriesIdIndex = d.series.index;
 
                 const scatterStyle =
-                    (d.series as ScatterSeries).symbol || getScatterStyle(seriesIdIndex);
+                    (d.series as ScatterSeries).symbol || getScatterStyle(seriesIdIndex || 0);
                 const scatterSymbol = getScatterSymbol(scatterStyle);
 
                 const size = d.data.radius ? d.data.radius * 2 : DEFAULT_SCATTER_POINT_SIZE;

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -10,7 +10,6 @@ import type {NodeWithD3Data} from '../../../utils';
 import {PreparedSeriesOptions} from '../../useSeries/types';
 import type {PreparedScatterData} from './prepare-data';
 import {shapeKey} from '../utils';
-import {ScatterSeries} from '../../../../../../types/widget-data';
 import {SymbolType} from '../../../../../../constants';
 
 export {prepareScatterData} from './prepare-data';
@@ -58,7 +57,7 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                 (exit) => exit.remove(),
             )
             .attr('d', (d) => {
-                const symbolType = (d.series as ScatterSeries).symbolType || SymbolType.Circle;
+                const symbolType = d.series.symbolType || SymbolType.Circle;
                 const scatterSymbol = getSymbol(symbolType);
 
                 // D3 takes size as square pixels, so we need to make square pixels size by multiplying

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -55,8 +55,6 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
         const hoverOptions = get(seriesOptions, 'scatter.states.hover');
         const inactiveOptions = get(seriesOptions, 'scatter.states.inactive');
 
-        const seriesIds: string[] = [];
-
         const selection = svgElement
             .selectAll('path')
             .data(preparedData, shapeKey)
@@ -66,13 +64,7 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                 (exit) => exit.remove(),
             )
             .attr('d', (d) => {
-                const seriesId = d.series.id;
-
-                let seriesIdIndex = seriesIds.indexOf(seriesId);
-                if (seriesIdIndex === -1) {
-                    seriesIds.push(seriesId);
-                    seriesIdIndex = seriesIds.length - 1;
-                }
+                const seriesIdIndex = d.series.index;
 
                 const scatterStyle =
                     (d.series as ScatterSeries).symbol || getScatterStyle(seriesIdIndex);

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -29,7 +29,7 @@ type ScatterSeriesShapeProps = {
 
 const b = block('d3-scatter');
 
-// const DEFAULT_SCATTER_POINT_CIRCLE_RADIUS = 4;
+const DEFAULT_SCATTER_POINT_SIZE = 8;
 
 const EMPTY_SELECTION = null as unknown as Selection<
     BaseType,
@@ -65,8 +65,11 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                     enter
                         .append('svg:path')
                         .attr('class', b('point'))
-                        .attr('transform', (d: {cx: number; cy: number}) => {
-                            return 'translate(' + (d.cx - 3) + ',' + (d.cy - 3) + ')';
+                        .attr('transform', (d) => {
+                            const size = d.data.radius || DEFAULT_SCATTER_POINT_SIZE;
+
+                            // Offset from top left point to center point of symbol shape
+                            return 'translate(' + (d.cx - size / 2) + ',' + (d.cy - size / 2) + ')';
                         })
                         .attr('d', (d) => {
                             const seriesId = d.series.id;
@@ -82,7 +85,10 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
                                 getScatterStyle(seriesIdIndex);
                             const scatterSymbol = getScatterSymbol(scatterStyle);
 
-                            return symbol(scatterSymbol, 48)();
+                            const size = d.data.radius || DEFAULT_SCATTER_POINT_SIZE;
+
+                            // To cast pixel size to d3 size we need to multiply this value by 6
+                            return symbol(scatterSymbol, size * 6)();
                         }),
                 (update) => update,
                 (exit) => exit.remove(),

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/index.tsx
@@ -61,38 +61,34 @@ export function ScatterSeriesShape(props: ScatterSeriesShapeProps) {
             .selectAll('path')
             .data(preparedData, shapeKey)
             .join(
-                (enter) =>
-                    enter
-                        .append('path')
-                        .attr('class', b('point'))
-                        .attr('transform', (d) => {
-                            const size = d.data.radius || DEFAULT_SCATTER_POINT_SIZE;
-
-                            // Offset from top left point to center point of symbol shape
-                            return 'translate(' + (d.cx - size / 2) + ',' + (d.cy - size / 2) + ')';
-                        })
-                        .attr('d', (d) => {
-                            const seriesId = d.series.id;
-
-                            let seriesIdIndex = seriesIds.indexOf(seriesId);
-                            if (seriesIdIndex === -1) {
-                                seriesIds.push(seriesId);
-                                seriesIdIndex = seriesIds.length - 1;
-                            }
-
-                            const scatterStyle =
-                                (d.series as ScatterSeries).symbol ||
-                                getScatterStyle(seriesIdIndex);
-                            const scatterSymbol = getScatterSymbol(scatterStyle);
-
-                            const size = d.data.radius || DEFAULT_SCATTER_POINT_SIZE;
-
-                            // To cast pixel size to d3 size we need to multiply this value by 6
-                            return symbol(scatterSymbol, size * 6)();
-                        }),
+                (enter) => enter.append('path').attr('class', b('point')),
                 (update) => update,
                 (exit) => exit.remove(),
             )
+            .attr('d', (d) => {
+                const seriesId = d.series.id;
+
+                let seriesIdIndex = seriesIds.indexOf(seriesId);
+                if (seriesIdIndex === -1) {
+                    seriesIds.push(seriesId);
+                    seriesIdIndex = seriesIds.length - 1;
+                }
+
+                const scatterStyle =
+                    (d.series as ScatterSeries).symbol || getScatterStyle(seriesIdIndex);
+                const scatterSymbol = getScatterSymbol(scatterStyle);
+
+                const size = d.data.radius ? d.data.radius * 2 : DEFAULT_SCATTER_POINT_SIZE;
+
+                // To cast pixel size to d3 size we need to multiply this value by 6
+                return symbol(scatterSymbol, size * 6)();
+            })
+            .attr('transform', (d) => {
+                const size = d.data.radius ? d.data.radius * 2 : DEFAULT_SCATTER_POINT_SIZE;
+
+                // Offset from top left point to center point of symbol shape
+                return 'translate(' + (d.cx - size / 2) + ',' + (d.cy - size / 2) + ')';
+            })
             .attr('fill', (d) => d.data.color || d.series.color || '');
 
         svgElement

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/prepare-data.ts
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/prepare-data.ts
@@ -5,7 +5,7 @@ import type {PreparedAxis} from '../../useChartOptions/types';
 import {PreparedScatterSeries} from '../../useSeries/types';
 import {getXValue, getYValue} from '../utils';
 
-const DEFAULT_SCATTER_POINT_SIZE = 8;
+const DEFAULT_SCATTER_POINT_SIZE = 7;
 
 export type PreparedScatterData = Omit<TooltipDataChunkScatter, 'series'> & {
     cx: number;

--- a/src/plugins/d3/renderer/hooks/useShapes/scatter/prepare-data.ts
+++ b/src/plugins/d3/renderer/hooks/useShapes/scatter/prepare-data.ts
@@ -5,6 +5,8 @@ import type {PreparedAxis} from '../../useChartOptions/types';
 import {PreparedScatterSeries} from '../../useSeries/types';
 import {getXValue, getYValue} from '../utils';
 
+const DEFAULT_SCATTER_POINT_SIZE = 8;
+
 export type PreparedScatterData = Omit<TooltipDataChunkScatter, 'series'> & {
     cx: number;
     cy: number;
@@ -12,6 +14,7 @@ export type PreparedScatterData = Omit<TooltipDataChunkScatter, 'series'> & {
     hovered: boolean;
     active: boolean;
     id: number;
+    size: number;
 };
 
 const getFilteredLinearScatterData = (data: ScatterSeriesData[]) => {
@@ -32,7 +35,10 @@ export const prepareScatterData = (args: {
             xAxis.type === 'category' || yAxis.type === 'category'
                 ? s.data
                 : getFilteredLinearScatterData(s.data);
+
         filteredData.forEach((d) => {
+            const size = d.radius ? d.radius * 2 : DEFAULT_SCATTER_POINT_SIZE;
+
             acc.push({
                 data: d,
                 series: s,
@@ -41,6 +47,7 @@ export const prepareScatterData = (args: {
                 hovered: false,
                 active: true,
                 id: acc.length - 1,
+                size,
             });
         });
 

--- a/src/plugins/d3/renderer/utils/index.ts
+++ b/src/plugins/d3/renderer/utils/index.ts
@@ -20,6 +20,7 @@ export * from './text';
 export * from './time';
 export * from './axis';
 export * from './labels';
+export * from './symbol';
 
 const CHARTS_WITHOUT_AXIS: ChartKitWidgetSeries['type'][] = ['pie'];
 

--- a/src/plugins/d3/renderer/utils/symbol.ts
+++ b/src/plugins/d3/renderer/utils/symbol.ts
@@ -1,9 +1,9 @@
 import {symbolDiamond2, symbolCircle, symbolSquare, symbolTriangle2} from 'd3';
 
-import {DotStyle} from '../../../../constants';
+import {SymbolType} from '../../../../constants';
 
 export const getSymbolType = (index: number) => {
-    const scatterStyles = Object.values(DotStyle);
+    const scatterStyles = Object.values(SymbolType);
 
     return scatterStyles[index % scatterStyles.length];
 };
@@ -22,17 +22,17 @@ const triangleDown = {
     },
 };
 
-export const getSymbol = (symbolType: string) => {
+export const getSymbol = (symbolType: SymbolType) => {
     switch (symbolType) {
-        case DotStyle.Diamond:
+        case SymbolType.Diamond:
             return symbolDiamond2;
-        case DotStyle.Circle:
+        case SymbolType.Circle:
             return symbolCircle;
-        case DotStyle.Square:
+        case SymbolType.Square:
             return symbolSquare;
-        case DotStyle.Triangle:
+        case SymbolType.Triangle:
             return symbolTriangle2;
-        case DotStyle.TriangleDown:
+        case SymbolType.TriangleDown:
             return triangleDown;
         default:
             return symbolCircle;

--- a/src/plugins/d3/renderer/utils/symbol.ts
+++ b/src/plugins/d3/renderer/utils/symbol.ts
@@ -1,0 +1,38 @@
+import {symbolDiamond2, symbolCircle, symbolSquare, symbolTriangle2} from 'd3';
+
+import {DotStyle} from '../../../../constants';
+
+export const getScatterStyle = (index: number) => {
+    const scatterStyles = Object.values(DotStyle);
+
+    return scatterStyles[index % scatterStyles.length];
+};
+
+const sqrt3 = Math.sqrt(3);
+const triangleDown = {
+    draw: (context: CanvasPath, size: number) => {
+        const y = -Math.sqrt(size / (sqrt3 * 3));
+
+        context.moveTo(0, -y * 2);
+        context.lineTo(-sqrt3 * y, y);
+        context.lineTo(sqrt3 * y, y);
+        context.closePath();
+    },
+};
+
+export const getScatterSymbol = (style: string) => {
+    switch (style) {
+        case DotStyle.Diamond:
+            return symbolDiamond2;
+        case DotStyle.Circle:
+            return symbolCircle;
+        case DotStyle.Square:
+            return symbolSquare;
+        case DotStyle.Triangle:
+            return symbolTriangle2;
+        case DotStyle.TriangleDown:
+            return triangleDown;
+        default:
+            return symbolCircle;
+    }
+};

--- a/src/plugins/d3/renderer/utils/symbol.ts
+++ b/src/plugins/d3/renderer/utils/symbol.ts
@@ -13,11 +13,12 @@ export const getSymbolType = (index: number) => {
 const sqrt3 = Math.sqrt(3);
 const triangleDown = {
     draw: (context: CanvasPath, size: number) => {
-        const y = -Math.sqrt(size / (sqrt3 * 3));
-
-        context.moveTo(0, -y * 2);
-        context.lineTo(-sqrt3 * y, y);
-        context.lineTo(sqrt3 * y, y);
+        const s = Math.sqrt(size) * 0.6824;
+        const t = s / 2;
+        const u = (s * sqrt3) / 2;
+        context.moveTo(0, s);
+        context.lineTo(u, -t);
+        context.lineTo(-u, -t);
         context.closePath();
     },
 };

--- a/src/plugins/d3/renderer/utils/symbol.ts
+++ b/src/plugins/d3/renderer/utils/symbol.ts
@@ -2,12 +2,14 @@ import {symbolDiamond2, symbolCircle, symbolSquare, symbolTriangle2} from 'd3';
 
 import {DotStyle} from '../../../../constants';
 
-export const getScatterStyle = (index: number) => {
+export const getSymbolType = (index: number) => {
     const scatterStyles = Object.values(DotStyle);
 
     return scatterStyles[index % scatterStyles.length];
 };
 
+// This is an inverted triangle
+// Based on https://github.com/d3/d3-shape/blob/main/src/symbol/triangle2.js
 const sqrt3 = Math.sqrt(3);
 const triangleDown = {
     draw: (context: CanvasPath, size: number) => {
@@ -20,8 +22,8 @@ const triangleDown = {
     },
 };
 
-export const getScatterSymbol = (style: string) => {
-    switch (style) {
+export const getSymbol = (symbolType: string) => {
+    switch (symbolType) {
         case DotStyle.Diamond:
             return symbolDiamond2;
         case DotStyle.Circle:

--- a/src/types/widget-data/legend.ts
+++ b/src/types/widget-data/legend.ts
@@ -69,8 +69,7 @@ export type PathLegendSymbolOptions = BaseLegendSymbol & {
 
 export type SymbolLegendSymbolOptions = BaseLegendSymbol & {
     /**
-     * The pixel size of the symbol for series types that use a path in the legend
-     * It needs to be casted to d3 size before using in d3.symbol
+     * The pixel width of the symbol for series types that use a symbol in the legend
      *
      * @default 8
      * */

--- a/src/types/widget-data/legend.ts
+++ b/src/types/widget-data/legend.ts
@@ -66,3 +66,12 @@ export type PathLegendSymbolOptions = BaseLegendSymbol & {
      * */
     width?: number;
 };
+
+export type SymbolLegendSymbolOptions = BaseLegendSymbol & {
+    /**
+     * Size of the d3 symbol that will be used as series symbol in legend
+     *
+     * @default 48
+     * */
+    width?: number;
+};

--- a/src/types/widget-data/legend.ts
+++ b/src/types/widget-data/legend.ts
@@ -69,9 +69,10 @@ export type PathLegendSymbolOptions = BaseLegendSymbol & {
 
 export type SymbolLegendSymbolOptions = BaseLegendSymbol & {
     /**
-     * Size of the d3 symbol that will be used as series symbol in legend
+     * The pixel size of the symbol for series types that use a path in the legend
+     * It needs to be casted to d3 size before using in d3.symbol
      *
-     * @default 48
+     * @default 8
      * */
     width?: number;
 };

--- a/src/types/widget-data/scatter.ts
+++ b/src/types/widget-data/scatter.ts
@@ -34,7 +34,7 @@ export type ScatterSeries<T = any> = BaseSeries & {
     /** The main color of the series (hex, rgba) */
     color?: string;
     /** A predefined shape or symbol for the dot */
-    symbol?: string;
+    symbolType?: string;
     // yAxisIndex?: number;
 
     /** Individual series legend options. Has higher priority than legend options in widget data */

--- a/src/types/widget-data/scatter.ts
+++ b/src/types/widget-data/scatter.ts
@@ -34,7 +34,7 @@ export type ScatterSeries<T = any> = BaseSeries & {
     /** The main color of the series (hex, rgba) */
     color?: string;
     /** A predefined shape or symbol for the dot */
-    symbolType?: SymbolType;
+    symbolType?: `${SymbolType}`;
     // yAxisIndex?: number;
 
     /** Individual series legend options. Has higher priority than legend options in widget data */

--- a/src/types/widget-data/scatter.ts
+++ b/src/types/widget-data/scatter.ts
@@ -1,4 +1,4 @@
-import {SeriesType} from '../../constants';
+import {SeriesType, SymbolType} from '../../constants';
 import type {BaseSeries, BaseSeriesData} from './base';
 import type {ChartKitWidgetLegend, RectLegendSymbolOptions} from './legend';
 
@@ -34,7 +34,7 @@ export type ScatterSeries<T = any> = BaseSeries & {
     /** The main color of the series (hex, rgba) */
     color?: string;
     /** A predefined shape or symbol for the dot */
-    symbolType?: string;
+    symbolType?: SymbolType;
     // yAxisIndex?: number;
 
     /** Individual series legend options. Has higher priority than legend options in widget data */


### PR DESCRIPTION
<img width="1274" alt="image" src="https://github.com/gravity-ui/chartkit/assets/15093838/81d410a6-0abd-47ba-a52d-aa29da832462">

Closes #311 