### PR TITLE
fix(Highcharts plugin): return old value for pie.slicedOffset

### DIFF
--- a/src/plugins/highcharts/renderer/helpers/config/config.js
+++ b/src/plugins/highcharts/renderer/helpers/config/config.js
@@ -1682,6 +1682,14 @@ export function prepareConfig(data, options, isMobile, holidays) {
                         }
                     },
                 },
+                point: {
+                    events: {
+                        click: function () {
+                            // Prevent slicing of pie segment after clicking it
+                            return false;
+                        },
+                    },
+                },
                 marker: options.splitTooltip
                     ? {
                           states: {

--- a/src/plugins/highcharts/renderer/helpers/config/options.js
+++ b/src/plugins/highcharts/renderer/helpers/config/options.js
@@ -78,7 +78,7 @@ const first = {
 
 const second = {
     allowPointSelect: true,
-    slicedOffset: 0,
+    slicedOffset: 20,
     cursor: 'pointer',
     showInLegend: true,
 };


### PR DESCRIPTION
I've previously changed it [here](https://github.com/gravity-ui/chartkit/commit/6fd4dea725d4a8981231c0e3b62c51c86ac34451#diff-6eab82a30f11808f01f15d4a6d80b63c89c17a908613765d4ace2dc23a9b6796L81)