### PR TITLE
fix(Highcharts plugin): fix `getTooltip` in case of tooltip fixation

### DIFF
--- a/src/plugins/highcharts/renderer/helpers/config/config.js
+++ b/src/plugins/highcharts/renderer/helpers/config/config.js
@@ -485,8 +485,21 @@ function validateCellManipulationConfig(tooltipOptions, property, item) {
     }
 }
 
+function getSeriesTypeFromTooltipContext() {
+    if (this.series) {
+        return this.series.type;
+    }
+
+    if (Array.isArray(this.points)) {
+        return this.points[0]?.series?.type;
+    }
+
+    return '';
+}
+
 function getTooltip(tooltip, options, comments, holidays) {
-    const serieType = (this.series && this.series.type) || tooltip.chart.options.chart.type;
+    const serieType =
+        getSeriesTypeFromTooltipContext.call(this) || tooltip.chart.options.chart.type;
     const chart = tooltip.chart;
     const xAxis = chart.xAxis[0];
     const isDatetimeXAxis = xAxis.options.type === 'datetime';


### PR DESCRIPTION
Fix this bug:

https://github.com/gravity-ui/chartkit/assets/26501073/bed7fbd7-b4a9-48e4-aa70-7263d12415af

