### PR TITLE
feat(tooltip): make background of hovered series more visible

### DIFF
--- a/src/components/ChartKit.scss
+++ b/src/components/ChartKit.scss
@@ -26,6 +26,7 @@
     --highcharts-tooltip-text: var(--g-color-text-primary);
     --highcharts-tooltip-bg: var(--highcharts-floating-bg);
     --highcharts-tooltip-alternate-bg: var(--g-color-base-generic);
+    --highcharts-tooltip-selected-bg: var(--g-color-base-info-medium);
     --highcharts-tooltip-text-complementary: var(--g-color-text-secondary);
     --highcharts-holiday-band: var(--g-color-base-generic);
 }

--- a/src/plugins/highcharts/renderer/helpers/tooltip/tooltip.scss
+++ b/src/plugins/highcharts/renderer/helpers/tooltip/tooltip.scss
@@ -196,6 +196,10 @@ $monospaceFontFamily: 'Consolas', 'Menlo', 'Ubuntu Mono', monospace;
                     ._tooltip-row-dark-bg {
                         background-color: var(--highcharts-tooltip-alternate-bg);
                     }
+
+                    ._tooltip-selected-row {
+                        background-color: var(--highcharts-tooltip-selected-bg);
+                    }
                 }
 
                 ._hidden-rows-sum {

--- a/src/plugins/yagr/renderer/tooltip/tooltip.scss
+++ b/src/plugins/yagr/renderer/tooltip/tooltip.scss
@@ -175,6 +175,10 @@
                     padding-bottom: 6px;
                     border-bottom: 1px solid var(--g-color-line-generic);
                 }
+
+                &._tooltip-header ._tooltip-selected-row {
+                    background-color: var(--g-color-base-info-medium);
+                }
             }
 
             tbody {


### PR DESCRIPTION

Currently, it's quite difficult to understand which series is being hovered by looking at the tooltip (especially in dark mode): 

<img width="534" height="479" alt="Screenshot 2025-07-10 at 19 05 43" src="https://github.com/user-attachments/assets/0ada3536-2370-497d-a830-689660a18f48" />

The only indication is the use of a bold font. It would probably be better to indicate the active series with a background color as well:

https://github.com/user-attachments/assets/b93fb95d-e1fc-48e7-ae68-9a5f5306c086

Also a few notes on yagr tooltips. By default, the yagr tooltips hovered series are rendered twice: once in place and once as the first row of the tooltip. In this case, a new background is added only to the first row, since that's where the user should look if they want to see the value of the active series:

<img width="388" height="310" alt="Screenshot 2025-07-10 at 19 12 01" src="https://github.com/user-attachments/assets/42a90583-0624-4a31-ae82-4b73a91c37c2" />
