### PR TITLE
fix(comments): redraw comments on zoom/unzoom for non-highstock charts

### DIFF
--- a/src/plugins/highcharts/renderer/helpers/config/config.js
+++ b/src/plugins/highcharts/renderer/helpers/config/config.js
@@ -410,16 +410,15 @@ function getTypeParams(data, options) {
         }
     }
 
-    if (options.highstock) {
-        params.xAxis.events = {};
-        params.xAxis.events.afterSetExtremes = (e) => {
+    params.xAxis.events = {
+        afterSetExtremes: (e) => {
             const chart = e.target.chart;
             if (chart.userOptions.isCallbackCalled) {
                 hideComments(chart, chart.userOptions._getComments(), chart.userOptions._config);
                 drawComments(chart, chart.userOptions._getComments(), chart.userOptions._config);
             }
-        };
-    }
+        },
+    };
 
     if (options.zones) {
         params.yAxis.plotBands = prepareZones(options);


### PR DESCRIPTION
Visual comments on non-highstock charts were not redrawn after zoom/unzoom. This caused comments outside the zoomed range to disappear permanently if the user toggled a legend item while zoomed in: `hideComments` + `drawComments` ran with the zoomed extremes (marking out-of-range comments as `isFit = false`), and when zooming out there was nothing to restore them.