### PR TITLE
feat: support React 19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,8 +32,8 @@
         "@types/d3-selection": "^3.0.10",
         "@types/lodash": "^4.14.177",
         "@types/node": "^18.0.0",
-        "@types/react": "^18.3.28",
-        "@types/react-dom": "^18.3.7",
+        "@types/react": "^19.2.16",
+        "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^5.1.4",
         "@vitest/browser-playwright": "^4.0.18",
         "@vitest/coverage-v8": "^4.0.18",
@@ -55,8 +55,8 @@
         "npm-run-all": "^4.1.5",
         "playwright": "^1.58.2",
         "prettier": "^3.2.5",
-        "react": "^18.3.1",
-        "react-dom": "^18.3.1",
+        "react": "^19.2.7",
+        "react-dom": "^19.2.7",
         "rimraf": "^5.0.5",
         "sass": "^1.56.2",
         "storybook": "^10.2.0",
@@ -69,7 +69,7 @@
       },
       "peerDependencies": {
         "@gravity-ui/uikit": "^7.0.0",
-        "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -3364,30 +3364,24 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/prop-types": {
-      "version": "15.7.5",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@types/react": {
-      "version": "18.3.28",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.28.tgz",
-      "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
+      "version": "19.2.16",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.16.tgz",
+      "integrity": "sha512-esJiCAnl0kfpNdE69f3So4WJUXy95dLZydX0KwK46riIHDzHM7O9Vtf9xCHW0PXIqvgqNrswl522kA/5yx+F4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/prop-types": "*",
         "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "18.3.7",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
-      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^18.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-redux": {
@@ -13218,14 +13212,11 @@
       }
     },
     "node_modules/react": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
-      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13288,17 +13279,16 @@
       }
     },
     "node_modules/react-dom": {
-      "version": "18.3.1",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
-      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.7.tgz",
+      "integrity": "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "loose-envify": "^1.1.0",
-        "scheduler": "^0.23.2"
+        "scheduler": "^0.27.0"
       },
       "peerDependencies": {
-        "react": "^18.3.1"
+        "react": "^19.2.7"
       }
     },
     "node_modules/react-is": {
@@ -14016,14 +14006,11 @@
       }
     },
     "node_modules/scheduler": {
-      "version": "0.23.2",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
-      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
+      "integrity": "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==",
       "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      }
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/package.json
+++ b/package.json
@@ -69,8 +69,8 @@
     "@types/d3-selection": "^3.0.10",
     "@types/lodash": "^4.14.177",
     "@types/node": "^18.0.0",
-    "@types/react": "^18.3.28",
-    "@types/react-dom": "^18.3.7",
+    "@types/react": "^19.2.16",
+    "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^5.1.4",
     "@vitest/browser-playwright": "^4.0.18",
     "@vitest/coverage-v8": "^4.0.18",
@@ -92,8 +92,8 @@
     "npm-run-all": "^4.1.5",
     "playwright": "^1.58.2",
     "prettier": "^3.2.5",
-    "react": "^18.3.1",
-    "react-dom": "^18.3.1",
+    "react": "^19.2.7",
+    "react-dom": "^19.2.7",
     "rimraf": "^5.0.5",
     "sass": "^1.56.2",
     "storybook": "^10.2.0",
@@ -106,7 +106,7 @@
   },
   "peerDependencies": {
     "@gravity-ui/uikit": "^7.0.0",
-    "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
+    "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
   },
   "scripts": {
     "test": "vitest run --project unit",

--- a/src/components/ChartKit.tsx
+++ b/src/components/ChartKit.tsx
@@ -18,7 +18,7 @@ type ChartKitComponentProps<T extends ChartKitType> = Omit<ChartKitProps<T>, 'on
 };
 
 const ChartKitComponent = <T extends ChartKitType>(props: ChartKitComponentProps<T>) => {
-    const widgetRef = React.useRef<ChartKitWidgetRef>();
+    const widgetRef = React.useRef<ChartKitWidgetRef | undefined>(undefined);
     const {instanceRef, id: propsId, type, isMobile, renderPluginLoader, ...restProps} = props;
 
     const ckId = React.useMemo(() => getRandomCKId(), []);

--- a/src/hooks/misc.ts
+++ b/src/hooks/misc.ts
@@ -1,7 +1,7 @@
 import React from 'react';
 
 export function usePrevious<T>(value: T) {
-    const ref = React.useRef<T>();
+    const ref = React.useRef<T | undefined>(undefined);
 
     React.useEffect(() => {
         ref.current = value;

--- a/src/plugins/highcharts/__stories__/components/ChartStory.tsx
+++ b/src/plugins/highcharts/__stories__/components/ChartStory.tsx
@@ -26,7 +26,7 @@ export const ChartStory: React.FC<ChartStoryProps> = (props: ChartStoryProps) =>
 
     const initRef = React.useRef(false);
     const [visible, setVisible] = React.useState(Boolean(props.visible));
-    const chartKitRef = React.useRef<ChartKitRef>();
+    const chartKitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
     if (!initRef.current) {
         if (!props.withoutPlugin) {

--- a/src/plugins/highcharts/__stories__/scatter/PerformanceIssue.stories.tsx
+++ b/src/plugins/highcharts/__stories__/scatter/PerformanceIssue.stories.tsx
@@ -21,7 +21,7 @@ type Story = StoryObj<typeof meta>;
 export const PerformanceIssue: Story = {
     render: () => {
         const [shown, setShown] = React.useState(false);
-        const chartkitRef = React.useRef<ChartKitRef>();
+        const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
         const widgetData = React.useMemo(() => {
             const categories = Array.from({length: 5000}).map((_, i) => String(i));

--- a/src/plugins/highcharts/renderer/components/HighchartsReact.tsx
+++ b/src/plugins/highcharts/renderer/components/HighchartsReact.tsx
@@ -12,7 +12,7 @@ import {useElementSize} from './useElementSize';
 
 interface HighchartsReactRefObject {
     chart: Highcharts.Chart | null | undefined;
-    container: React.RefObject<HTMLDivElement | undefined>;
+    container: React.RefObject<HTMLDivElement | null>;
 }
 
 interface HighchartsReactProps {
@@ -33,7 +33,7 @@ export const HighchartsReact = React.memo(
         function HighchartsReact(props, ref) {
             const {onRender} = props;
             const containerRef = React.useRef<HTMLDivElement | null>(null);
-            const chartRef = React.useRef<Highcharts.Chart | null>();
+            const chartRef = React.useRef<Highcharts.Chart | null>(null);
             const {width, height} = useElementSize(containerRef);
             const performanceMeasure = React.useRef<ReturnType<typeof measurePerformance> | null>(
                 measurePerformance(),

--- a/src/plugins/indicator/__stories__/Indicator.stories.tsx
+++ b/src/plugins/indicator/__stories__/Indicator.stories.tsx
@@ -32,7 +32,7 @@ interface ChartStoryProps {
 
 const ChartStory = ({color, size, title, nowrap}: ChartStoryProps) => {
     const [shown, setShown] = React.useState(false);
-    const chartkitRef = React.useRef<ChartKitRef>();
+    const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
     const resultData = cloneDeep(data);
 
     if (resultData.data) {

--- a/src/plugins/yagr/__stories__/Playground.stories.tsx
+++ b/src/plugins/yagr/__stories__/Playground.stories.tsx
@@ -61,7 +61,7 @@ function prepareData(): YagrWidgetData {
 
 const ChartStory = ({data}: {data: YagrWidgetData}) => {
     const [shown, setShown] = React.useState(false);
-    const chartkitRef = React.useRef<ChartKitRef>();
+    const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
     if (!shown) {
         settings.set({plugins: [YagrPlugin]});

--- a/src/plugins/yagr/__stories__/Yagr.stories.tsx
+++ b/src/plugins/yagr/__stories__/Yagr.stories.tsx
@@ -72,7 +72,7 @@ function Tooltip({yagr}: CustomTooltipProps) {
 export const Line: Story = {
     render: () => {
         const [shown, setShown] = React.useState(false);
-        const chartkitRef = React.useRef<ChartKitRef>();
+        const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
         if (!shown) {
             settings.set({plugins: [YagrPlugin]});
@@ -90,7 +90,7 @@ export const Line: Story = {
 export const Updates: Story = {
     render: () => {
         const [shown, setShown] = React.useState(false);
-        const chartkitRef = React.useRef<ChartKitRef>();
+        const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
         const [state, setState] = React.useState(line10);
 
@@ -118,7 +118,7 @@ export const Updates: Story = {
 export const CustomTooltip: Story = {
     render: () => {
         const [shown, setShown] = React.useState(false);
-        const chartkitRef = React.useRef<ChartKitRef>();
+        const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
         const [state, setState] = React.useState(line10);
 
@@ -145,7 +145,7 @@ export const CustomTooltip: Story = {
 export const Area: Story = {
     render: () => {
         const [shown, setShown] = React.useState(false);
-        const chartkitRef = React.useRef<ChartKitRef>();
+        const chartkitRef = React.useRef<ChartKitRef | undefined>(undefined);
 
         if (!shown) {
             settings.set({plugins: [YagrPlugin]});


### PR DESCRIPTION
## Summary
- Extends the `react` peer dependency range with `^19.0.0` (kept `^16.0.0 || ^17.0.0 || ^18.0.0` for backwards compatibility).
- Bumps `react`/`react-dom` dev deps and `@types/react`/`@types/react-dom` to `^19`.
- Adjusts a handful of type-level usages to satisfy stricter typings in `@types/react@19`:
  - Replaces `useRef<T>()` with `useRef<T | undefined>(undefined)` / `useRef<T | null>(null)` — the zero-argument overload was removed.
  - Tightens `HighchartsReactRefObject.container` to `RefObject<HTMLDivElement | null>`.

No runtime behaviour changes; `forwardRef`, `React.FC` and other still-supported APIs were intentionally left in place to keep the diff small.

## Compatibility
- `@gravity-ui/uikit@^7` already declares `react ^16.14 || ^17 || ^18 || ^19` as a peer.
- `@gravity-ui/charts@^1.55` accepts `react >=17.0.0`.
- No other workspace peer constraints had to change.