### PR TITLE
fix(gravity-charts): keep split tooltip hover highlight + stabilize visual tests

### DIFF
--- a/src/plugins/gravity-charts/__tests__/Base.visual.test.tsx
+++ b/src/plugins/gravity-charts/__tests__/Base.visual.test.tsx
@@ -1,12 +1,9 @@
-import React from 'react';
-
 import type {ChartData} from '@gravity-ui/charts';
 
-import {render} from '../../../../test-utils/utils.js';
 import {settings} from '../../../libs/index.js';
 import {GravityChartsPlugin} from '../index.js';
 
-import {CHART_TEST_STORY_DATA_QA, ChartTestStory} from './ChartTestStory.js';
+import {CHART_TEST_STORY_DATA_QA, renderChartStory} from './ChartTestStory.js';
 
 describe('GravityCharts base tests', () => {
     beforeAll(() => {
@@ -29,13 +26,13 @@ describe('GravityCharts base tests', () => {
                 ],
             },
         };
-        const screen = await render(<ChartTestStory data={data} />);
+        const screen = await renderChartStory({data});
         await expect(screen.getByTestId(CHART_TEST_STORY_DATA_QA)).toMatchScreenshot();
     });
 
     test('should display "No data" when series is empty', async () => {
         const data: ChartData = {series: {data: []}};
-        const screen = await render(<ChartTestStory data={data} />);
+        const screen = await renderChartStory({data});
         await expect.element(screen.getByText('No data')).toBeVisible();
     });
 });

--- a/src/plugins/gravity-charts/__tests__/ChartTestStory.tsx
+++ b/src/plugins/gravity-charts/__tests__/ChartTestStory.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import type {ChartData} from '@gravity-ui/charts';
 
+import {render} from '../../../../test-utils/utils.js';
 import {ChartKit} from '../../../components/ChartKit.js';
 
 export const CHART_TEST_STORY_DATA_QA = 'chart-test-story-data-qa';
@@ -10,9 +11,11 @@ type Props = {
     data: ChartData;
     styles?: React.CSSProperties;
     tooltip?: {splitted?: boolean};
+    onRender?: () => void;
+    onError?: () => void;
 };
 
-export const ChartTestStory = ({data, styles, tooltip}: Props) => {
+export const ChartTestStory = ({data, styles, tooltip, onRender, onError}: Props) => {
     const containerStyle: React.CSSProperties = {
         height: '100vh',
         width: '100vw',
@@ -21,7 +24,44 @@ export const ChartTestStory = ({data, styles, tooltip}: Props) => {
 
     return (
         <div style={containerStyle} data-qa={CHART_TEST_STORY_DATA_QA}>
-            <ChartKit type="gravity-charts" data={data} tooltip={tooltip} />
+            <ChartKit
+                type="gravity-charts"
+                data={data}
+                tooltip={tooltip}
+                onRender={onRender}
+                onError={onError}
+            />
         </div>
     );
 };
+
+/**
+ * Renders {@link ChartTestStory} and resolves once the chart has settled — either after
+ * `@gravity-ui/charts` finishes its (asynchronous) render (`onRender`, fired by
+ * `GravityChartsWidget` once the chart calls `onReady`), or after the `ErrorBoundary` catches a
+ * render error such as the empty-data "No data" case (`onError`). Awaiting this guarantees the DOM
+ * is in its final state before assertions / `toMatchScreenshot` run, for both populated and empty
+ * data.
+ */
+export async function renderChartStory(
+    props: Omit<Props, 'onRender' | 'onError'>,
+    options?: Parameters<typeof render>[1],
+) {
+    let resolveSettled: () => void = () => {};
+    const settled = new Promise<void>((resolve) => {
+        resolveSettled = resolve;
+    });
+
+    const screen = await render(
+        <ChartTestStory
+            {...props}
+            onRender={() => resolveSettled()}
+            onError={() => resolveSettled()}
+        />,
+        options,
+    );
+
+    await settled;
+
+    return screen;
+}

--- a/src/plugins/gravity-charts/__tests__/SplitTooltip.visual.test.tsx
+++ b/src/plugins/gravity-charts/__tests__/SplitTooltip.visual.test.tsx
@@ -1,13 +1,10 @@
-import React from 'react';
-
 import type {ChartData} from '@gravity-ui/charts';
 import {page} from 'vitest/browser';
 
-import {render} from '../../../../test-utils/utils.js';
 import {settings} from '../../../libs/index.js';
 import {GravityChartsPlugin} from '../index.js';
 
-import {CHART_TEST_STORY_DATA_QA, ChartTestStory} from './ChartTestStory.js';
+import {CHART_TEST_STORY_DATA_QA, renderChartStory} from './ChartTestStory.js';
 
 const SPLIT_TOOLTIP_DATA: ChartData = {
     series: {
@@ -32,8 +29,8 @@ describe('Split tooltip visual tests', () => {
 
     test('should render tooltip in album orientation', async () => {
         await page.viewport(600, 280);
-        const screen = await render(
-            <ChartTestStory data={SPLIT_TOOLTIP_DATA} tooltip={{splitted: true}} />,
+        const screen = await renderChartStory(
+            {data: SPLIT_TOOLTIP_DATA, tooltip: {splitted: true}},
             {providers: {theme: 'dark'}},
         );
         await expect(screen.getByTestId(CHART_TEST_STORY_DATA_QA)).toMatchScreenshot();
@@ -41,8 +38,8 @@ describe('Split tooltip visual tests', () => {
 
     test('should render tooltip in portrait orientation', async () => {
         await page.viewport(280, 400);
-        const screen = await render(
-            <ChartTestStory data={SPLIT_TOOLTIP_DATA} tooltip={{splitted: true}} />,
+        const screen = await renderChartStory(
+            {data: SPLIT_TOOLTIP_DATA, tooltip: {splitted: true}},
             {providers: {theme: 'dark'}},
         );
         await expect(screen.getByTestId(CHART_TEST_STORY_DATA_QA)).toMatchScreenshot();

--- a/src/plugins/gravity-charts/renderer/withSplitPane/withSplitPane.tsx
+++ b/src/plugins/gravity-charts/renderer/withSplitPane/withSplitPane.tsx
@@ -35,6 +35,10 @@ const SplitPaneContent = (
     const {data, height, ChartComponent, ...restProps} = props;
     const tooltipContainerRef = React.useRef<HTMLDivElement | null>(null);
     const chartRef = React.useRef<ChartRef>(null);
+    // Remounts the chart when the chart pane is first resized to fit the split tooltip (see below).
+    // The chart applies `data.defaultState.hoveredPosition` only once per mount, so a resize would
+    // otherwise leave the chart without its initial highlight while the tooltip still shows it.
+    const [chartGeneration, setChartGeneration] = React.useState(0);
     const tooltipRef = React.useRef<TooltipContentRef>(null);
     const shouldShowTooltip = React.useRef<boolean>(false);
     const {
@@ -62,10 +66,12 @@ const SplitPaneContent = (
     ) {
         const containerHeight = height;
         if (containerHeight - RESIZER_HEIGHT === size) {
+            // Shrink the chart pane to make room for the tooltip, then remount the chart (via
+            // `chartGeneration`) instead of reflowing it. A `reflow()` resizes the chart but drops
+            // its default hovered point, desyncing it from the split tooltip; remounting re-applies
+            // `defaultState` at the new size so the hovered bar stays highlighted.
             setSize(containerHeight - RESIZER_HEIGHT - tooltipHeight);
-            queueMicrotask(() => {
-                chartRef.current?.reflow({immediate: true});
-            });
+            setChartGeneration((generation) => generation + 1);
         }
     }
 
@@ -181,7 +187,14 @@ const SplitPaneContent = (
             split={split}
             onChange={handleSizeChange}
             resizerStyle={shouldShowTooltip.current ? undefined : {display: 'none'}}
-            paneOneRender={() => <ChartComponent {...restProps} ref={chartRef} data={resultData} />}
+            paneOneRender={() => (
+                <ChartComponent
+                    key={chartGeneration}
+                    {...restProps}
+                    ref={chartRef}
+                    data={resultData}
+                />
+            )}
             paneTwoRender={() => (
                 <div ref={tooltipContainerRef}>
                     <TooltipContent


### PR DESCRIPTION
## Two complementary fixes

### 1. Product bug — split tooltip loses its hover highlight (`withSplitPane`)
The split tooltip seeds an initial hovered point via `data.defaultState.hoveredPosition`, but `@gravity-ui/charts` applies that **once per mount** (`useDefaultState` is guarded by a one-shot ref, and `ChartRef` only exposes `reflow()`).

In the **horizontal** split (portrait, `innerWidth ≤ innerHeight`), the tooltip pane's appearance triggers a chart-pane resize + `chartRef.reflow({immediate:true})`. That reflow re-renders the chart and **drops the one-shot highlight**, leaving the chart desynced from the tooltip pane it still shows (pane says "hovering A", but bar A is no longer highlighted). The **vertical** split (album) has no such reflow, so it kept the highlight.

**Fix:** replace that post-resize `reflow()` with a one-time chart **remount** (`key={chartGeneration}`, bumped only in the initial-resize branch — *not* on user drag-resizes). A fresh mount sizes correctly at the shrunk pane **and** re-applies `defaultState`, so the hovered bar stays highlighted and in sync with the tooltip.

### 2. Test flake — blank-canvas race (visual tests)
The gravity-charts visual tests captured the screenshot immediately after `render()`, but the chart renders asynchronously, so on slow/loaded CI runners `toMatchScreenshot` caught a blank canvas (surfaced by the charts `1.55.2 → 1.56.0` bump, [failed run](https://github.com/gravity-ui/chartkit/actions/runs/27338492635/job/80768842932)).

**Fix:** new `renderChartStory(props, options)` helper in `ChartTestStory` forwards `onRender` and `onError` into `<ChartKit>` and resolves on whichever settles first — `onRender` (chart painted) or `onError` (ErrorBoundary caught a render error, e.g. the empty-data "No data" case). Every gravity-charts visual test uses it, so assertions/screenshots run only once the DOM has settled — for both populated and empty data, with no hang.
