### PR TITLE
docs: add package update request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/package-update-request.yml
+++ b/.github/ISSUE_TEMPLATE/package-update-request.yml
@@ -1,0 +1,28 @@
+name: 📦 Package update request
+description: Request an update of a bundled Gravity UI charting package (@gravity-ui/charts and/or @gravity-ui/yagr).
+title: 'Update Gravity UI packages: '
+labels:
+  - dependencies
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Use this form to request an update of a charting library that ChartKit depends on.
+  - type: checkboxes
+    id: packages
+    attributes:
+      label: Packages to update
+      description: Select at least one package you want to be updated.
+      options:
+        - label: '`@gravity-ui/charts`'
+        - label: '`@gravity-ui/yagr`'
+    validations:
+      required: true
+  - type: input
+    id: target-version
+    attributes:
+      label: Target version(s)
+      description: Optional. The specific version(s) you need. Leave empty to update to the latest available.
+      placeholder: 'e.g. @gravity-ui/charts@x.y.z'
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each plugin renderer is lazy-loaded, so the underlying library code is only down
 ## Table of contents
 
 - [Get started](#get-started)
+- [Updating charting packages](#updating-charting-packages)
 - [Development](#development)
 
 ## Get started
@@ -96,6 +97,15 @@ export default function App() {
 ```
 
 `ChartKit` adapts to its parent's size — make sure the container has an explicit height.
+
+## Updating charting packages
+
+ChartKit bundles two Gravity UI charting libraries as dependencies:
+
+- [`@gravity-ui/charts`](https://github.com/gravity-ui/charts) — powers the `gravity-charts` plugin
+- [`@gravity-ui/yagr`](https://github.com/gravity-ui/yagr) — powers the `yagr` plugin
+
+If you need a newer version of one of these packages, open a [Package update request](https://github.com/gravity-ui/ChartKit/issues/new?template=package-update-request.yml) issue and select the package(s) you need. Maintainers will bump the selected packages and release the update.
 
 ## Development
 


### PR DESCRIPTION
## What

Adds a way for external users to request an update of the bundled Gravity UI charting packages.

- **New issue form** — `.github/ISSUE_TEMPLATE/package-update-request.yml`. A GitHub Issue Form with checkboxes to select `@gravity-ui/charts` and/or `@gravity-ui/yagr` (at least one required) and an optional target-version field. Auto-labels the issue with `dependencies`.
- **README** — new "Updating charting packages" section (and TOC entry) pointing users to the issue form when they need a newer version of one of these packages.

## Why

External consumers had no clear path to ask for a dependency bump. The `Update Gravity UI Packages` workflow is maintainer-triggered; this gives users a structured request entry point that maintainers can act on.