### PR TITLE
fix: remove baseUrl, use relative imports

### DIFF
--- a/src/libs/settings/__tests__/settings-update.test.ts
+++ b/src/libs/settings/__tests__/settings-update.test.ts
@@ -1,5 +1,4 @@
-import {ChartKitPlugin} from 'src/types';
-
+import type {ChartKitPlugin} from '../../../types';
 import {settings} from '../settings';
 
 const resetSettings = () => settings.set({lang: 'en'});

--- a/src/libs/settings/mergeSettingStrategy.ts
+++ b/src/libs/settings/mergeSettingStrategy.ts
@@ -1,7 +1,7 @@
 import isObject from 'lodash/isObject';
 import mergeWith from 'lodash/mergeWith';
 
-import {ChartKitPlugin} from 'src/types';
+import type {ChartKitPlugin} from '../../types';
 
 // @ts-ignore
 export function mergeSettingStrategy(objValue: any, srcValue: any, key: string): any {

--- a/src/plugins/yagr/types.ts
+++ b/src/plugins/yagr/types.ts
@@ -1,7 +1,7 @@
 import type {MinimalValidConfig, RawSerieData, YagrConfig} from '@gravity-ui/yagr';
 import type Yagr from '@gravity-ui/yagr';
 
-import {ChartKitProps} from 'src/types';
+import type {ChartKitProps} from '../../types';
 
 export type {default as Yagr} from '@gravity-ui/yagr';
 export type {YagrReactRef} from '@gravity-ui/yagr/react';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "outDir": "build/esm",
     "module": "esnext",
     "jsx": "react",
-    "baseUrl": ".",
     "importHelpers": true,
     "moduleResolution": "bundler",
     "resolveJsonModule": true


### PR DESCRIPTION
Usage of `baseUrl` allows TS to resolve non-reralative imports relative to `baseUrl`, this makes produced types broken